### PR TITLE
Fix to sorting asc / desc sincne +/- are not valid url

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,10 +191,10 @@ when dealing with fields that do not exist to avoid consumers breaking.
 
 Some service resources will need provide sorting options, for example sorting a list of
 products by price. This should be achieved via a `sort` query parameter followed by a
-comma list of fields to sort on, each prefixed with a `+` or `-` to indicate ascending or
+comma list of fields to sort on, each prefixed with a `asc` or `desc` to indicate ascending or
 descending ordering.
 
-`GET /products?sort=-price,+name`
+`GET /products?sort=desc:price,asc:name`
 
 This would ask the products list resource to return results sorted descending by price and
 then ascending by name.


### PR DESCRIPTION
This PR updates our specification to replace `+/-` with `asc/desc` for sorting since `+/-` are not valid in url query parameters.